### PR TITLE
fix: 대시보드 현재 회차 타임존 문제 수정

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import {type ClassValue, clsx} from "clsx"
 import {twMerge} from "tailwind-merge"
 import type {Building, Round} from "@/lib/interfaces"
 import {NotificationMessage} from "@/components/contexts/NotificationContext";
+import { format } from 'date-fns-tz';
 
 // cn 함수
 export function cn(...inputs: ClassValue[]) {
@@ -111,7 +112,7 @@ export function calculateTotalSlots(building: Building): number {
 
 // 현재 날짜가 포함된 회차 반환
 export function findCurrentRound(rounds: Round[], currentDate: Date = new Date()): Round | null {
-  const today = currentDate.toISOString().split("T")[0] // YYYY-MM-DD 형식
+  const today = format(currentDate, 'yyyy-MM-dd', { timeZone: 'Asia/Seoul' });
 
   // 현재 날짜가 포함된 회차 찾기
   const currentRound = rounds.find((round) => {


### PR DESCRIPTION
- close #2 
```diff
- const today = currentDate.toISOString().split("T")[0] // YYYY-MM-DD 형식
+ const today = format(currentDate, 'yyyy-MM-dd', { timeZone: 'Asia/Seoul' });
```

기존 currentDate.toISOString() 부분에서 날짜 객체를 무조건 UTC(GMT+0) 시간으로 변환한 뒤에 ISO 형식의 문자열로 만들어 KST가 아닌 UTC 날짜로 변환되어 연장신청일 오전 9시까지 이전 회차로 자동 선택되는 문제를 KST를 기준으로 변환하도록 하여 해결하였습니다.